### PR TITLE
Add host to skip hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ $ gitcd https://github.com/facebook/react
 # => ~/myworkspace/github.com/facebook/react
 ```
 
+To omit the <host> part from the local clone path, set `GITCD_USEHOST` to `false` (the value is not case sensitive).
+
+Example:
+
+```sh
+$ export GITCD_HOME=~/myworkspace GITCD_USEHOST=false
+$ gitcd https://github.com/facebook/react
+# => ~/myworkspace/facebook/react
+```
+
 ## Test
 
 ```sh

--- a/gitcd.plugin.zsh
+++ b/gitcd.plugin.zsh
@@ -45,6 +45,11 @@ _giturl2dir() {
     # 替换掉第一个冒号，即 github.com:foo/bar => github.com/foo/bar
     url=${url/:/\/}
 
+    [[ -n $GITCD_USEHOST ]] && [[ "${GITCD_USEHOST:l}" == "false" ]] && {
+        # echo $url
+        url=$(echo $url | cut -d "/" -f 2-)
+    }
+
     # 用 echo 返回给调用方，而不是用 return
     echo $url
 }

--- a/test.zsh
+++ b/test.zsh
@@ -26,4 +26,22 @@ assert_ok $(_giturl2dir 'git@github.com:cnpm/cnpm') 'github.com/cnpm/cnpm'
 assert_ok $(_giturl2dir 'git@gitcafe.com:fengmk2/cnpm.git') 'gitcafe.com/fengmk2/cnpm'
 assert_ok $(_giturl2dir 'git@gist.github.com:3135914.git') 'gist.github.com/3135914'
 
+GITCD_USEHOST=False
+
+assert_ok $(_giturl2dir 'git://gitlab.com/edp/logger.git') 'edp/logger'
+assert_ok $(_giturl2dir 'git@gitlab.com:edp/logger.git') 'edp/logger'
+assert_ok $(_giturl2dir 'git://github.com/treygriffith/cellar.git') 'treygriffith/cellar'
+assert_ok $(_giturl2dir 'git@gitlab.xxx.com:frontend/arch/xxx.git') 'frontend/arch/xxx'
+assert_ok $(_giturl2dir 'https://github.com/banchee/tranquil.git') 'banchee/tranquil'
+assert_ok $(_giturl2dir 'https://github.com/banchee/tranquil') 'banchee/tranquil'
+assert_ok $(_giturl2dir 'http://github.com/banchee/tranquil.git') 'banchee/tranquil'
+assert_ok $(_giturl2dir 'git+https://github.com/banchee/tranquil.git') 'banchee/tranquil'
+assert_ok $(_giturl2dir 'github.com/banchee/tranquil.git') 'banchee/tranquil'
+assert_ok $(_giturl2dir 'https://jpillora@github.com/banchee/tranquil.git') 'banchee/tranquil'
+assert_ok $(_giturl2dir 'git@github.com:cnpm/cnpm.git') 'cnpm/cnpm'
+assert_ok $(_giturl2dir 'github.com:cnpm/cnpm.git') 'cnpm/cnpm'
+assert_ok $(_giturl2dir 'git@github.com:cnpm/cnpm') 'cnpm/cnpm'
+assert_ok $(_giturl2dir 'git@gitcafe.com:fengmk2/cnpm.git') 'fengmk2/cnpm'
+assert_ok $(_giturl2dir 'git@gist.github.com:3135914.git') '3135914'
+
 print -P "%B%F{green}All Pass!"


### PR DESCRIPTION
Provides option to omit the <host> part in the local clone path.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>